### PR TITLE
feat: add just run-vm to simplify testing

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,4 +13,7 @@ RUN --mount=type=tmpfs,dst=/var \
     --mount=type=bind,from=ctx,source=/,dst=/tmp/ctx \
     /tmp/ctx/build.sh
 
+LABEL containers.bootc=1
+LABEL org.opencontainers.image.source="https://github.com/projectbluefin/distroless"
+
 RUN bootc container lint


### PR DESCRIPTION
Added `--format oci` to be consistent with the build.yml using `oci: true` in CI
Added `--security-opt label=disable`  to `build-containerfile` for consistency