### PR TITLE
Change the build system around to fix updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,15 +79,51 @@ jobs:
           sep-tags: " "
           sep-annotations: " "
 
+      - name: Mount BTRFS for podman storage
+        id: container-storage-action
+        uses: ublue-os/container-storage-action@911baca08baf30c8654933e9e9723cb399892140
+        with:
+          mount-opts: noatime,compress-force=zstd:2
+
+      - name: Mount BTRFS for /var/tmp
+        id: var-tmp-action
+        uses: ublue-os/container-storage-action@911baca08baf30c8654933e9e9723cb399892140
+        with:
+          mount-opts: noatime,compress-force=zstd:2
+          target-dir: /var/tmp
+
+      # - name: Build Image
+      #   id: build_image
+      #   uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
+      #   with:
+      #     containerfiles: ./Containerfile
+      #     image: ${{ env.IMAGE_NAME }}
+      #     tags: ${{ steps.metadata.outputs.tags }}
+      #     labels: ${{ steps.metadata.outputs.labels }}
+      #     oci: true
+      # 
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
-        with:
-          containerfiles: ./Containerfile
-          image: ${{ env.IMAGE_NAME }}
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}
-          oci: true
+        env:
+          META_LABELS: ${{ steps.metadata.outputs.labels }}
+          META_TAGS: ${{ steps.metadata.outputs.tags }}
+        run: |
+          set -x
+          BUILD_ARGS=("--squash-all")
+
+          # get tags from metadata action
+          for tag in $META_TAGS; do
+            BUILD_ARGS+=("--tag" "$IMAGE_NAME:$tag")
+          done
+
+          # get labels from metadata action
+          while IFS= read -r label; do
+          if [[ -n "$label" ]]; then
+            BUILD_ARGS+=("--label" "$label")
+          fi
+          done <<< "$META_LABELS"
+
+          podman build "${BUILD_ARGS[@]}" .
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3


### PR DESCRIPTION
For whatever reason, the default GnomeOS nightly image is built in such a way that `composefs-rs` throws a temper tantrum when you try to update with `bootc upgrade`. Thankfully, squashing the image down with `podman build --squash-all` fixes this problem easily!

Here's problem number 2: `buildah build` does not have `--squash-all` as an option. It has `--squash`, but that option will only squash layers created **in the image build,** and does not squash the image that the Containerfile is based off of. So I had to replace the build system with `podman build` to make this work the way I want it to.

Updates will still be scuffed because GnomeOS nightly is still on `bootc` 1.10.0 for some reason (although it [will be updated to 1.12.0](https://gitlab.gnome.org/GNOME/gnome-build-meta/-/commit/e416137e88e48f811a96b860f0e666dba494e897) very soon, thanks GnomeOS devs). Of course, the composefs backend (which we are using in dakotaraptor/distroless) is [experimental](https://bootc-dev.github.io/bootc/experimental-composefs.html) and is therefore subject to breaking change, so until it's stable, even with the ability to update, you should expect breakage on your composefs installation. Always.

In summary, this PR:
- Adds ublue-os/container-storage-action to both `~/.local/share/containers` and `/var/tmp` (yes we really do need a mount for /var/tmp, `--squash-all` uses that space HEAVILY)
- Replaces `redhat-actions/buildah-build` with `podman build` while still respecting the metadata generated by `docker/metadata-action`
- Adds `--squash-all` to the build arguments, allowing for `bootc upgrade` and `bootc switch` to work properly