### PR TITLE
Re-add fallocate in `generate-bootable-image`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -19,6 +19,10 @@ bootc *ARGS:
 
 generate-bootable-image $base_dir=base_dir $filesystem=filesystem:
     #!/usr/bin/env bash
+    if [ ! -e "${base_dir}/bootable.img" ] ; then
+        echo "Allocating 50G for bootable.img..."
+        fallocate -l 50G "${base_dir}/bootable.img"
+    fi
 
     just bootc install to-disk --composefs-backend \
          --via-loopback /data/bootable.img \


### PR DESCRIPTION
https://github.com/projectbluefin/dakota/commit/5bc6cfabdfa472b53d9d8513d279574f2d3546a5 was committed on accident, this pr fixes this mistake